### PR TITLE
[C조] 간편메뉴 / 권한: 일반사원

### DIFF
--- a/src/layout/Header/Header.tsx
+++ b/src/layout/Header/Header.tsx
@@ -31,7 +31,9 @@ export default function Header() {
           </Link>
         )}
         <div className="px-4 py-3.5 text-sm border-x border-gray-50 hover:cursor-pointer">
-          {/* 간편메뉴를 누르면 어떤일이 발생?? */}간편메뉴
+          <Link to="/simple-menu">
+            <div>간편메뉴</div>
+          </Link>
         </div>
       </div>
     </header>

--- a/src/pages/simpleMenu/SimpleMenu.tsx
+++ b/src/pages/simpleMenu/SimpleMenu.tsx
@@ -1,33 +1,69 @@
-import React from 'react';
-import { PiCalendarDotsLight } from 'react-icons/pi';
-import { PiClockLight } from 'react-icons/pi';
+import {
+  PiCalendarDotsLight,
+  PiClockLight,
+  PiFileTextThin,
+  PiMapPinArea,
+  PiUserCircleThin,
+} from 'react-icons/pi';
+import { Link } from 'react-router-dom';
 
 export default function SimpleMenu() {
   return (
-    <div className="flex">
-      <div className="flex">
-        <div>
-          <PiCalendarDotsLight size={24} />
-        </div>
-        <div>연차신청</div>
+    <div className="flex w-full gap-2">
+      <div
+        className="flex grow items-center justify-center border border-slate-300 rounded-2xl hover:cursor-pointer
+      hover:bg-slate-200"
+      >
+        <Link to="" className="flex gap-2 items-center justify-center">
+          <div>
+            <PiCalendarDotsLight size={24} />
+          </div>
+          <div className="text-x">연차신청</div>
+        </Link>
       </div>
-      <div className="flex">
-        <div>
-          <PiClockLight size={24} />
-        </div>
-        <div>O.T/휴일근무 신청</div>
+      <div
+        className="flex grow items-center justify-center border border-slate-300 rounded-2xl hover:cursor-pointer
+      hover:bg-slate-200"
+      >
+        <Link to="" className="flex gap-2 items-center justify-center">
+          <div>
+            <PiClockLight size={24} />
+          </div>
+          <div className="text-x">O.T/휴일근무 신청</div>
+        </Link>
       </div>
-      <div className="flex">
-        <div></div>
-        <div>증명서신청</div>
+      <div
+        className="flex grow items-center justify-center border border-slate-300 rounded-2xl hover:cursor-pointer
+      hover:bg-slate-200"
+      >
+        <Link to="" className="flex gap-2 items-center justify-center">
+          <div>
+            <PiFileTextThin size={24} />
+          </div>
+          <div className="text-x">증명서신청</div>
+        </Link>
       </div>
-      <div className="flex">
-        <div></div>
-        <div>마이페이지</div>
+      <div
+        className="flex grow items-center justify-center border border-slate-300 rounded-2xl hover:cursor-pointer
+      hover:bg-slate-200"
+      >
+        <Link to="" className="flex gap-2 items-center justify-center">
+          <div>
+            <PiUserCircleThin size={24} />
+          </div>
+          <div className="text-x">마이페이지</div>
+        </Link>
       </div>
-      <div className="flex">
-        <div></div>
-        <div>출/퇴근</div>
+      <div
+        className="flex grow items-center justify-center border border-slate-300 rounded-2xl hover:cursor-pointer
+      hover:bg-slate-200"
+      >
+        <Link to="" className="flex gap-2 items-center justify-center">
+          <div>
+            <PiMapPinArea size={24} />
+          </div>
+          <div className="text-x">출/퇴근</div>
+        </Link>
       </div>
     </div>
   );

--- a/src/pages/simpleMenu/SimpleMenu.tsx
+++ b/src/pages/simpleMenu/SimpleMenu.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { PiCalendarDotsLight } from 'react-icons/pi';
+import { PiClockLight } from 'react-icons/pi';
+
+export default function SimpleMenu() {
+  return (
+    <div className="flex">
+      <div className="flex">
+        <div>
+          <PiCalendarDotsLight size={24} />
+        </div>
+        <div>연차신청</div>
+      </div>
+      <div className="flex">
+        <div>
+          <PiClockLight size={24} />
+        </div>
+        <div>O.T/휴일근무 신청</div>
+      </div>
+      <div className="flex">
+        <div></div>
+        <div>증명서신청</div>
+      </div>
+      <div className="flex">
+        <div></div>
+        <div>마이페이지</div>
+      </div>
+      <div className="flex">
+        <div></div>
+        <div>출/퇴근</div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/simpleMenu/SimpleMenuPage.tsx
+++ b/src/pages/simpleMenu/SimpleMenuPage.tsx
@@ -7,7 +7,7 @@ import {
 } from 'react-icons/pi';
 import { Link } from 'react-router-dom';
 
-export default function SimpleMenu() {
+export default function SimpleMenuPage() {
   return (
     <div className="flex w-full gap-2">
       <div

--- a/src/pages/simpleMenu/SimpleMenuPage.tsx
+++ b/src/pages/simpleMenu/SimpleMenuPage.tsx
@@ -1,3 +1,4 @@
+import { Txt } from '@/components/Common/Txt';
 import {
   PiCalendarDotsLight,
   PiClockLight,
@@ -18,7 +19,7 @@ export default function SimpleMenuPage() {
           <div>
             <PiCalendarDotsLight size={24} />
           </div>
-          <div className="text-x">연차신청</div>
+          <Txt variant="h6">연차신청</Txt>
         </Link>
       </div>
       <div
@@ -29,7 +30,7 @@ export default function SimpleMenuPage() {
           <div>
             <PiClockLight size={24} />
           </div>
-          <div className="text-x">O.T/휴일근무 신청</div>
+          <Txt variant="h6">O.T/휴일근무 신청</Txt>
         </Link>
       </div>
       <div
@@ -40,7 +41,7 @@ export default function SimpleMenuPage() {
           <div>
             <PiFileTextThin size={24} />
           </div>
-          <div className="text-x">증명서신청</div>
+          <Txt variant="h6">증명서신청</Txt>
         </Link>
       </div>
       <div
@@ -51,7 +52,7 @@ export default function SimpleMenuPage() {
           <div>
             <PiUserCircleThin size={24} />
           </div>
-          <div className="text-x">마이페이지</div>
+          <Txt variant="h6">마이페이지</Txt>
         </Link>
       </div>
       <div
@@ -62,7 +63,7 @@ export default function SimpleMenuPage() {
           <div>
             <PiMapPinArea size={24} />
           </div>
-          <div className="text-x">출/퇴근</div>
+          <Txt variant="h6">출/퇴근</Txt>
         </Link>
       </div>
     </div>

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,7 +16,7 @@ import MemberInfoPage from '@/pages/memberManagement/MemberInfoPage';
 import MemberManagementPage from '@/pages/memberManagement/MemberManagementPage';
 import ManagementOfficePage from '@/pages/officeSetting/ManagementOfficePage';
 import SalarySettlementPage from '@/pages/salarySettlement/SalarySettlementPage';
-import SimpleMenu from '@/pages/simpleMenu/SimpleMenu';
+import SimpleMenuPage from '@/pages/simpleMenu/SimpleMenuPage';
 import BoardViewPage from '@/pages/userBoard/view/BoardViewPage';
 import BoardWritePage from '@/pages/userBoard/write/BoardWritePage';
 import WorkManagementPage from '@/pages/workManagement/WorkManagementPage';
@@ -140,7 +140,7 @@ const router = createBrowserRouter([
       },
       {
         path: 'simple-menu',
-        element: <SimpleMenu />,
+        element: <SimpleMenuPage />,
       },
     ],
   },

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -16,6 +16,7 @@ import MemberInfoPage from '@/pages/memberManagement/MemberInfoPage';
 import MemberManagementPage from '@/pages/memberManagement/MemberManagementPage';
 import ManagementOfficePage from '@/pages/officeSetting/ManagementOfficePage';
 import SalarySettlementPage from '@/pages/salarySettlement/SalarySettlementPage';
+import SimpleMenu from '@/pages/simpleMenu/SimpleMenu';
 import BoardViewPage from '@/pages/userBoard/view/BoardViewPage';
 import BoardWritePage from '@/pages/userBoard/write/BoardWritePage';
 import WorkManagementPage from '@/pages/workManagement/WorkManagementPage';
@@ -136,6 +137,10 @@ const router = createBrowserRouter([
             element: <BoardWritePage />,
           },
         ],
+      },
+      {
+        path: 'simple-menu',
+        element: <SimpleMenu />,
       },
     ],
   },


### PR DESCRIPTION
## 관련 이슈
- #135 
## 주요 변경 사항
- 일반 사원에게 보여지는 간편메뉴 UI를 개발하였습니다.

## 스크린샷
<img width="1918" alt="image" src="https://github.com/user-attachments/assets/f5af8ec0-d403-474a-9426-9037c2766f8b">

## 전달사항(세심하게 봐야 할 부분 / 고민점
- 각 `<Link>`의 `to`속성에 경로를 어디로 보내야할지 확실하게 몰라서 비워두었습니다.