### PR TITLE
[C조] 휴무 캘린더의  불필요한 effect 및 refetch 제거

### DIFF
--- a/src/components/HolidayCalendar/HolidayCalendar.tsx
+++ b/src/components/HolidayCalendar/HolidayCalendar.tsx
@@ -3,7 +3,6 @@ import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin, { DateClickArg } from '@fullcalendar/interaction';
 import FullCalendar from '@fullcalendar/react';
 import dayjs from 'dayjs';
-import { useEffect } from 'react';
 
 import Badge from '@/components/Common/LabelBadge';
 import { Txt } from '@/components/Common/Txt';
@@ -30,13 +29,8 @@ export default function HolidayCalendar({
   isSundayOff,
   branch_id,
 }: IHolidayCalendarProps) {
-  const { data: holidays, refetch: refetchHoliDays, isLoading } = useGetClosedDays({ branch_id });
-  // const { data: holidays, refetch } = useGetMonthlyClosedDays({ branch_id, date: currDate.toDate() });  // 월별 휴무일 조회
-
-  useEffect(() => {
-    console.log('%c refetch 실행', 'color: green; font-size: 15px;');
-    refetchHoliDays();
-  }, [branch_id, refetchHoliDays]);
+  const { data: holidays, isLoading } = useGetClosedDays({ branch_id });
+  // const { data: holidays } = useGetMonthlyClosedDays({ branch_id, date: currDate.toDate() });  // 월별 휴무일 조회
 
   const handleDateClick = (arg: DateClickArg) => {
     onDateAndEventClick(arg.date);


### PR DESCRIPTION
## 관련 이슈
#157 
경택님의 A조 코드리뷰를 보고 문득 떠올라서 수정했습니다.
register와 deletion에서 API 요청 후에 refetch를 호출하며, queryKey도 branch_id 값을 캐싱하고 있기 때문에 Calendar에서 branch_id 값을 useEffect로 감시할 이유가 없었습니다.
실제로 코드 수정 후에도 문제없이 동작하는 것 확인했습니다.

## 주요 변경 사항
-
-

## 스크린샷

## 전달사항(세심하게 봐야 할 부분 / 고민점)