### PR TITLE
[FEAT] 회원관리-파트/통합관리자 관리 권한변경 모달 제작

### DIFF
--- a/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingCheckboxGroup.tsx
+++ b/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingCheckboxGroup.tsx
@@ -1,0 +1,25 @@
+import { CheckboxGroup } from '@radix-ui/themes';
+import React from 'react';
+
+interface IProps {
+  options: { name: string; id: number }[];
+  value: { name: string; id: number }[];
+  onChange: (e) => void;
+}
+
+export default function SuperManagerSettingCheckboxGroup({ options, value, onChange }: IProps) {
+  return (
+    <CheckboxGroup.Root
+      defaultValue={value.map((v) => `${v.id}`)}
+      onValueChange={(newData) => onChange(newData)}
+      name="example"
+      className="flex-row flex-wrap"
+    >
+      {options.map((option) => (
+        <CheckboxGroup.Item key={option.id} className="w-[127px] mb-2" value={option.id.toString()}>
+          {option.name}
+        </CheckboxGroup.Item>
+      ))}
+    </CheckboxGroup.Root>
+  );
+}

--- a/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalContainer.tsx
+++ b/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalContainer.tsx
@@ -1,0 +1,46 @@
+import { Button, Dialog } from '@radix-ui/themes';
+import React from 'react';
+
+import Title from '@/components/Common/Title';
+
+interface IProps {
+  children: React.ReactNode;
+  height?: string;
+  onSubmit: () => void;
+}
+
+export default function SuperManagerSettingModalContainer({ children, height, onSubmit }: IProps) {
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <Button
+          variant="surface"
+          radius="none"
+          color="gray"
+          size="3"
+          className="font-semibold text-black text-sm py-4 px-8 bg-gray-200 border-gray-10"
+        >
+          권한변경
+        </Button>
+      </Dialog.Trigger>
+      <Dialog.Content className="overflow-y-hidden">
+        <Dialog.Title className="absolute t-0 l-0 text-transparent">
+          파트/통합관리자관리
+        </Dialog.Title>
+        <Dialog.Description></Dialog.Description>
+
+        <form onSubmit={onSubmit} className="">
+          <div>
+            <Title content="세부권한" />
+          </div>
+          <div className={`p-4 ${height ? `${height} overflow-y-auto` : ''}`}>{children}</div>
+          <div className="flex justify-center pt-2">
+            <Button size="3" className="bg-black">
+              수정하기
+            </Button>
+          </div>
+        </form>
+      </Dialog.Content>
+    </Dialog.Root>
+  );
+}

--- a/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalPartVer.tsx
+++ b/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalPartVer.tsx
@@ -1,0 +1,113 @@
+import { Controller, useForm } from 'react-hook-form';
+
+import { Txt } from '@/components/Common/Txt';
+import SuperManagerSettingCheckboxGroup from '@/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingCheckboxGroup';
+import SuperManagerSettingModalContainer from '@/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalContainer';
+
+const settingOptions = [
+  { id: 1, name: 'P.T관리' },
+  { id: 2, name: '계약관리(P.T포함)' },
+  { id: 3, name: '휴무관리' },
+  { id: 4, name: 'O.T관리' },
+  { id: 5, name: '인사관리' },
+  { id: 6, name: '근로관리' },
+  { id: 7, name: '급여정산' },
+  { id: 8, name: '문서설정관리' },
+  { id: 9, name: '휴직관리' },
+  { id: 10, name: '출퇴근기록관리' },
+];
+
+// 체크된 아이템의 아이디와 이름을 모두 받아온다는 가정으로 작성한 코드입니다.
+interface ISuperManagerSettingPart {
+  코디네이터: { name: string; id: number }[];
+  시설관리: { name: string; id: number }[];
+  세탁실: { name: string; id: number }[];
+}
+
+export default function SuperManagerSettingModalPartVer() {
+  const { control, handleSubmit } = useForm<ISuperManagerSettingPart>({
+    defaultValues: {
+      코디네이터: [
+        { id: 1, name: 'P.T관리' },
+        { id: 2, name: '계약관리(P.T포함)' },
+        { id: 3, name: '휴무관리' },
+        { id: 4, name: 'O.T관리' },
+        { id: 5, name: '인사관리' },
+        { id: 6, name: '근로관리' },
+        { id: 7, name: '급여정산' },
+        { id: 8, name: '문서설정관리' },
+        { id: 9, name: '휴직관리' },
+        { id: 10, name: '출퇴근기록관리' },
+      ],
+      시설관리: [
+        { id: 4, name: 'O.T관리' },
+        { id: 5, name: '인사관리' },
+        { id: 6, name: '근로관리' },
+        { id: 7, name: '급여정산' },
+      ],
+      세탁실: [{ id: 1, name: 'P.T관리' }],
+    },
+  });
+
+  const onSubmit = handleSubmit((data: ISuperManagerSettingPart) => {
+    console.log(data);
+  });
+
+  const sectionTitleStyle = 'block w-40 px-6 py-1 border border-gary-50 mb-2 ';
+  return (
+    <SuperManagerSettingModalContainer onSubmit={onSubmit} height="max-h-[calc(100vh-250px)]">
+      <ul>
+        <li className="mb-6">
+          <Txt variant="h6" className={sectionTitleStyle}>
+            코디네이터
+          </Txt>
+          <Controller
+            control={control}
+            name="코디네이터"
+            render={({ field: { value, onChange } }) => (
+              <SuperManagerSettingCheckboxGroup
+                onChange={onChange}
+                value={value}
+                options={settingOptions}
+              />
+            )}
+          />
+        </li>
+
+        <li className="mb-6">
+          <Txt variant="h6" className={sectionTitleStyle}>
+            시설관리
+          </Txt>
+          <Controller
+            control={control}
+            name="시설관리"
+            render={({ field: { value, onChange } }) => (
+              <SuperManagerSettingCheckboxGroup
+                onChange={onChange}
+                value={value}
+                options={settingOptions}
+              />
+            )}
+          />
+        </li>
+
+        <li className="mb-6">
+          <Txt variant="h6" className={sectionTitleStyle}>
+            세탁실
+          </Txt>
+          <Controller
+            control={control}
+            name="세탁실"
+            render={({ field: { value, onChange } }) => (
+              <SuperManagerSettingCheckboxGroup
+                onChange={onChange}
+                value={value}
+                options={settingOptions}
+              />
+            )}
+          />
+        </li>
+      </ul>
+    </SuperManagerSettingModalContainer>
+  );
+}

--- a/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalSuperVer.tsx
+++ b/src/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalSuperVer.tsx
@@ -1,0 +1,58 @@
+import { Controller, useForm } from 'react-hook-form';
+
+import SuperManagerSettingCheckboxGroup from '@/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingCheckboxGroup';
+import SuperManagerSettingModalContainer from '@/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalContainer';
+
+const settingOptions = [
+  { id: 1, name: '계약관리(P.T포함)' },
+  { id: 2, name: '휴무관리' },
+  { id: 3, name: 'O.T관리' },
+  { id: 4, name: '인사관리' },
+  { id: 5, name: '근로관리' },
+  { id: 6, name: '급여정산' },
+  { id: 7, name: '문서설정관리' },
+  { id: 8, name: '휴직관리' },
+  { id: 9, name: '출퇴근기록관리' },
+];
+
+export interface ISuperManagerSettingSuper {
+  통합관리자: { name: string; id: number }[];
+}
+
+export default function SuperManagerSettingModalSuperVer() {
+  const { control, handleSubmit } = useForm<ISuperManagerSettingSuper>({
+    defaultValues: {
+      통합관리자: [
+        { id: 1, name: '계약관리(P.T포함)' },
+        { id: 2, name: '휴무관리' },
+        { id: 3, name: 'O.T관리' },
+        { id: 4, name: '인사관리' },
+        { id: 5, name: '근로관리' },
+        { id: 6, name: '급여정산' },
+        { id: 7, name: '문서설정관리' },
+        { id: 8, name: '휴직관리' },
+        { id: 9, name: '출퇴근기록관리' },
+      ],
+    },
+  });
+
+  const onSubmit = handleSubmit((data: ISuperManagerSettingSuper) => {
+    console.log(data);
+  });
+
+  return (
+    <SuperManagerSettingModalContainer onSubmit={onSubmit}>
+      <Controller
+        control={control}
+        name="통합관리자"
+        render={({ field: { value, onChange } }) => (
+          <SuperManagerSettingCheckboxGroup
+            onChange={onChange}
+            value={value}
+            options={settingOptions}
+          />
+        )}
+      />
+    </SuperManagerSettingModalContainer>
+  );
+}

--- a/src/pages/memberManagement/SuperManagerSetting.tsx
+++ b/src/pages/memberManagement/SuperManagerSetting.tsx
@@ -3,8 +3,12 @@ import { PiGear } from 'react-icons/pi';
 import { Link } from 'react-router-dom';
 
 import ContactSearchInput from '@/components/Common/ContactSearchInput';
+import Badge from '@/components/Common/LabelBadge';
+import Pagination from '@/components/Common/Pagination';
 import SelectBox from '@/components/Common/Select';
 import TitleContainer from '@/components/Common/TitleContainer';
+import SuperManagerSettingModalPartVer from '@/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalPartVer';
+import SuperManagerSettingModalSuperVer from '@/components/MemberManagement/SuperManagerSettingModal/SuperManagerSettingModalSuperVer';
 
 export default function SuperManagerSetting() {
   // 회원관리 버튼 클릭 시
@@ -82,6 +86,7 @@ export default function SuperManagerSetting() {
             </Table.ColumnHeaderCell>
           </Table.Row>
         </Table.Header>
+
         <Table.Body>
           {Object.values(SUPERMANAGERSETTING_TABLE_TITLE).map((data, dataIndex) => (
             <Table.Row key={dataIndex} align="center">
@@ -90,9 +95,7 @@ export default function SuperManagerSetting() {
                   <Table.Cell justify="center" align="center" key={entryIndex}>
                     <div className="flex gap-2">
                       {data[key].map((part, index) => (
-                        <div key={index} className="bg-gray-200 rounded-md px-1.5">
-                          {part}
-                        </div>
+                        <Badge size={1} text={part} color="purple" key={index} radius="small" />
                       ))}
                     </div>
                   </Table.Cell>
@@ -103,21 +106,18 @@ export default function SuperManagerSetting() {
                 );
               })}
               <Table.Cell justify="center" align="center">
-                <Button
-                  variant="surface"
-                  radius="none"
-                  color="gray"
-                  size="3"
-                  className="font-semibold text-black text-sm py-4 px-8 bg-gray-200 border-gray-10"
-                  onClick={() => {}}
-                >
-                  권한변경
-                </Button>
+                {data.권한 === '통합관리자' ? (
+                  <SuperManagerSettingModalSuperVer />
+                ) : (
+                  <SuperManagerSettingModalPartVer />
+                )}
               </Table.Cell>
             </Table.Row>
           ))}
         </Table.Body>
       </Table.Root>
+
+      <Pagination totalItems={7} itemsPerPage={10} />
     </div>
   );
 }
@@ -149,7 +149,7 @@ const SUPERMANAGERSETTING_TABLE_TITLE: TSUPERMANAGERSETTING_TABLE_TITLE = [
     근무파트: '의사',
     연락처: '010-1234-5678',
     이메일: 'email@mement.ai',
-    권한: '통합관리자',
+    권한: '파트관리자',
     파트: ['전체'],
   },
   {


### PR DESCRIPTION
## 관련 이슈

- #257 

## 주요 변경 사항
- 통합관리자 모달 UI
- 파트관리자 모달 UI
- 모달 react-hook-form 연결
- 페이지네이션 추가

## 스크린샷
- 통합관리자 권한 변경 모달
<img width="650" alt="스크린샷 2024-10-24 오후 6 41 36" src="https://github.com/user-attachments/assets/4751e6dc-9d45-4bf8-bb21-9dedbce9d743">

- 파트관리자 권한 변경 모달
<img width="642" alt="스크린샷 2024-10-24 오후 6 41 44" src="https://github.com/user-attachments/assets/55d61f1a-e146-4be8-bb34-d094e3b30df7">

- 페이지네이션과 라벨 색상 변경한 파트/통합 관리자 페이지
<img width="1681" alt="스크린샷 2024-10-24 오후 7 08 21" src="https://github.com/user-attachments/assets/e8d59aba-18cf-4406-a9c0-db5e144251e5">

## 전달사항(세심하게 봐야 할 부분 / 고민점)


